### PR TITLE
Update log parser for new format

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -184,8 +184,8 @@ inline uint64_t unmorton(uint64_t x) {
 }
 BOOST_FUSION_ADAPT_STRUCT(
   log_line_for_qi,
-  (zxy_t, zxy)
   (ip_addr_for_qi, ip_addr)
+  (zxy_t, zxy)
   );
 
 BOOST_FUSION_ADAPT_STRUCT(
@@ -219,12 +219,18 @@ struct log_line_parser : qi::grammar<Iterator, log_line_for_qi()> {
     using qi::lexeme;
     using qi::char_;
 
-    top = omit[double_] >> lit(" ") // time
-      >> path >> lit(" ")
-      >> omit[quoted_string] >> lit(" ") // etag?
-      >> ip_addr >> lit(" ")
-      >> omit[quoted_string] // user agent
-      >> -(lit(" ") >> omit[int_]) // bytes
+    top = omit[double_] >> lit(" ")          // timestamp
+      >> omit[int_] >> lit(" ")              // response time
+      >> ip_addr >> lit(" ")                 // client address
+      >> omit[symbol] >> lit("/")            // squid status
+      >> omit[int_] >> lit(" ")              // http status
+      >> omit[int_] >> lit(" ")              // response size
+      >> omit[symbol] >> lit(" ")            // request method
+      >> path >> lit(" ")                    // request path
+      >> omit[symbol] >> lit("/")            // squid hierarchy status
+      >> omit[host_name] >> lit(" ")         // peer name
+      >> omit[quoted_string] >> lit(" ")     // referer
+      >> omit[quoted_string]                 // user agent
       ;
 
     path = (
@@ -243,6 +249,11 @@ struct log_line_parser : qi::grammar<Iterator, log_line_for_qi()> {
 
     quoted_string = lit("\"") >> *((char_ - '"' - '\\') || ('\\' >> char_)) >> lit("\"");
 
+    symbol = char_("A-Z") >> *char_("A-Z_");
+
+    host_name = char_("A-Za-z") >> *char_("A-Za-z0-9-") >>
+      *(lit(".") >> char_("A-Za-z") >> *char_("A-Za-z0-9-"));
+
     /*
     qi::debug(top);
     qi::debug(path);
@@ -260,6 +271,8 @@ struct log_line_parser : qi::grammar<Iterator, log_line_for_qi()> {
   qi::rule<Iterator, zxy_t()> path;
   qi::rule<Iterator, ip_addr_for_qi()> ip_addr;
   qi::rule<Iterator, std::string()> quoted_string;
+  qi::rule<Iterator, std::string()> symbol;
+  qi::rule<Iterator, std::string()> host_name;
 };
 
 std::list<fs::path> file_parser(fs::path input_file,


### PR DESCRIPTION
Reflects merger (per https://github.com/openstreetmap/chef/issues/94) of the standard squid access log with the custom log previously used for this analysis and the nginx logs.

The new format is defined by the following squid format string:

```
%ts.%03tu %tr %>a %Ss/%03Hs %<st %rm %rp %Sh/%<A %mt "%{Referer}>h" "%{User-Agent}>h"
```

which breaks down as:

```
%ts.%03tu          <seconds since epoch>.<subsecond time>
%6tr               <response time - milliseconds>
%>a                <client source IP address>
%Ss/%03Hs          <squid request status>/<HTTP status code>
%<st               <reply size including HTTP headers>
%rm                <request method>
%rp                <request URL-Path excluding hostname>
%Sh/%<A            <squid hierarchy status>/<server ip address or peer name>
%mt                <mime content type>
"%{Referer}>h"     <user agent request header>
"%{User-Agent}>h"  <user agent request header>
```

Note that with this update only the new style logs will be processed - not sure what the best way is of making it handle both if that is necessary?